### PR TITLE
Add page configuration to Streamlit pages

### DIFF
--- a/pages/1_add_activity.py
+++ b/pages/1_add_activity.py
@@ -3,6 +3,8 @@ import datetime
 import uuid
 from common import get_supabase, get_browser_timezone, back_to_feed
 
+st.set_page_config(page_title="Productivity Tracker", page_icon="📋", layout="wide")
+
 st.header("➕ Add Your Offline Activity")
 
 supabase = get_supabase()

--- a/pages/2_edit_activity.py
+++ b/pages/2_edit_activity.py
@@ -5,6 +5,8 @@ import re
 import uuid
 from common import get_supabase, get_browser_timezone, to_local_series, back_to_feed
 
+st.set_page_config(page_title="Productivity Tracker", page_icon="📋", layout="wide")
+
 st.header("✏️ Edit or Delete Activities")
 
 supabase = get_supabase()

--- a/productivity tracker.py
+++ b/productivity tracker.py
@@ -2,6 +2,8 @@ import streamlit as st
 import pandas as pd
 from common import get_supabase, get_browser_timezone, to_local_series, go_to_add_activity
 
+st.set_page_config(page_title="Productivity Tracker", page_icon="📋", layout="wide")
+
 st.header("📋 Activity Feed")
 
 supabase = get_supabase()


### PR DESCRIPTION
## Summary
- Initialize Streamlit pages with `st.set_page_config` for consistent app metadata
- Apply page config to add and edit activity pages and main feed

## Testing
- `python -m py_compile 'productivity tracker.py' pages/1_add_activity.py pages/2_edit_activity.py`


------
https://chatgpt.com/codex/tasks/task_e_6898ef040c1c83229ac2add87c48e41a