### PR TITLE
Use column layout for image gallery

### DIFF
--- a/productivity tracker.py
+++ b/productivity tracker.py
@@ -45,12 +45,14 @@ st.line_chart(pivot)
 if st.button("📷 Load Feed of Images"):
     st.subheader("Activity Image Gallery")
     images_df = df[(~df["image_url"].isna()) & (df["image_url"].astype(str).str.len() > 0)]
-    for _, row in images_df.iterrows():
+    num_cols = 3
+    cols = st.columns(num_cols)
+    for idx, (_, row) in enumerate(images_df.iterrows()):
         when = row["date_local"].strftime("%Y-%m-%d %H:%M") if pd.notnull(row["date_local"]) else ""
         mins = int(row.get("duration_minutes", 0) or 0)
-        st.image(
+        cols[idx % num_cols].image(
             row["image_url"],
             caption=f"{row['name']} ({row['category']}) • {row['user']} • {when} • {mins} min",
-            width=400,
+            width=250,
         )
     st.markdown("---")


### PR DESCRIPTION
## Summary
- Display image feed in a three-column grid using `st.columns`
- Keep captions and widths uniform for a balanced gallery

## Testing
- `python -m py_compile 'productivity tracker.py'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898ef131c28832297bfad2150b71dc5